### PR TITLE
Удалена лишняя информация об операционной системе при вызове команды picodata --version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,7 @@ fn insert_build_metadata() {
     rustc::env("BUILD_PROFILE", build_profile);
 
     let os_version = std::process::Command::new("uname")
-        .args(["-srmo"])
+        .args(["-sm"])
         .output()
         .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
         .unwrap_or_else(|_| "unknown".to_string());

--- a/src/info.rs
+++ b/src/info.rs
@@ -35,7 +35,6 @@ pub fn version_for_help() -> &'static str {
         result.push_str(crate::tarantool::version());
         result.push('\n');
 
-        result.push_str("target: ");
         result.push_str(env!("OS_VERSION"));
         result
     })


### PR DESCRIPTION
1. Ключи при вызове команды uname заменены на -sm;
2. Убрано слово "target:" в выводе ключа --version.

Пример нового вывода команды picodata --version
```
picodata 25.2.0-61-gacb773dc, static, release
tarantool (fork) version: 2.11.5-174-gcb6d026ae
Linux x86_64
```
В исходном тикете не ясно, обязательно ли должно быть слово `linux` с маленькой буквы. Утилита uname выводит `Linux`.
https://git.picodata.io/core/picodata/-/issues/1415