### PR TITLE
Реализована сериализация без использования временной хэш таблицы

### DIFF
--- a/src/pgproto/backend/describe.rs
+++ b/src/pgproto/backend/describe.rs
@@ -19,9 +19,9 @@ use sbroad::{
         Plan,
     },
 };
-use serde::Serialize;
+use serde::{ser::SerializeMap, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::{collections::HashMap, iter::zip, os::raw::c_int};
+use std::{iter::zip, os::raw::c_int};
 use tarantool::{
     proc::{Return, ReturnMsgpack},
     tuple::FunctionCtx,
@@ -289,8 +289,9 @@ impl Serialize for MetadataColumn {
     where
         S: serde::Serializer,
     {
-        let map = HashMap::from([(self.name.clone(), self.ty.to_string())]);
-        map.serialize(serializer)
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(&self.name, &self.ty.to_string())?;
+        map.end()
     }
 }
 


### PR DESCRIPTION
Честно говоря, я не понял, как можно реализовать в этом методе сериализацию через пакет rmpv. Этот пакет сериализует данные в байтовый поток и предъявляет к типу ограничения `S: Write`. `serde::Serializer` не реализует типаж `Write`. Чтобы задействовать rmpv, я полагаю, придется поменять сигнатуру метода и также переписать метод десериализации.
Поэтому сделал аналогично тому, как это реализовано в [sbroad/sbroad-core/src/executor/result.rs](https://github.com/picodata/picodata/blob/master/sbroad/sbroad-core/src/executor/result.rs)
