### PR TITLE
fix(sql): unhandled white spaces in trim() function

### DIFF
--- a/sbroad/sbroad-core/src/frontend/sql/query.pest
+++ b/sbroad/sbroad-core/src/frontend/sql/query.pest
@@ -446,7 +446,7 @@ Expr = ${ ExprAtomValue ~ (ExprInfixOpo ~ ExprAtomValue)* }
             CurrentDate = { ^"current_date" }
             LocalTimestamp = { ^"localtimestamp" ~ (WO ~ "(" ~ WO ~ Unsigned ~ WO ~ ")")? }
             Trim = ${
-                ^"trim" ~ WO ~ "(" ~ (TrimOption ~ W ~ ^"from" ~ W)? ~ TrimTarget ~ ")"
+                ^"trim" ~ WO ~ "(" ~ WO ~ (TrimOption ~ W ~ ^"from" ~ W)? ~ TrimTarget ~ WO ~ ")"
             }
                 TrimOption = _{ ((TrimKind ~ W)? ~ TrimPattern) | TrimKind }
                 TrimKind = { (TrimKindLeading | TrimKindTrailing | TrimKindBoth) }


### PR DESCRIPTION
Hi there just fixed this small issue.
Thanks for comments at the bottom of the file.

```text
sql> select trim(    'kek'    );
+-------+
| col_1 |
+=======+
| kek   |
+-------+
```

close: https://git.picodata.io/core/picodata/-/issues/1738

PS: I was not able to register at your platform, so here we go.

![image](https://github.com/user-attachments/assets/d76fb6ef-fe34-46bf-b737-aff94bc6d749)
